### PR TITLE
Salutation error

### DIFF
--- a/src/edu/wright/cs/raiderplanner/controller/AccountController.java
+++ b/src/edu/wright/cs/raiderplanner/controller/AccountController.java
@@ -58,6 +58,7 @@ public class AccountController implements Initializable {
 	@FXML private GridPane pane;
 	@FXML private Alert invalidInputAlert = new Alert(AlertType.ERROR);
 	@FXML private Alert emptyNameAlert = new Alert(AlertType.CONFIRMATION);
+	@FXML private Alert emptySalutationAlert = new Alert(AlertType.CONFIRMATION);
 
 	private Account account;
 	private boolean success = false;
@@ -174,6 +175,7 @@ public class AccountController implements Initializable {
 		String invalidMessage = "";
 		boolean validSuccess = true;
 		boolean validName = true;
+		boolean noSalutation = false;
 		if (!validateNumber()) {
 			invalidMessage += "Please enter a valid W Number\n";
 			validSuccess = false;
@@ -187,17 +189,32 @@ public class AccountController implements Initializable {
 			validSuccess = false;
 		}
 		if (!validateSalutation()) {
-			invalidMessage += "Please enter a valid salutation\n";
-			validSuccess = false;
+			if (this.salutation.getValue() == null) {
+				if (!this.handleEmptySalutation()) {
+					validSuccess = false;
+				} else {
+					noSalutation = true;
+				}
+			} else {
+				invalidMessage += "Please enter a valid salutation\n";
+				validSuccess = false;
+			}
 		}
 		if (this.fullName.getText().trim().isEmpty()) {
 			if (!this.handleEmptyName()) {
 				validName = false;
 			}
 		}
-		if (validSuccess && validName) {
+		if (validSuccess && validName && !noSalutation) {
 			Person pers = new Person(this.salutation.getSelectionModel().getSelectedItem().trim(),
 					this.fullName.getText().trim(), this.famLast.isSelected());
+			this.account = new Account(pers, this.accountNo.getText().trim());
+			this.success = true;
+			Stage stage = (Stage) this.submit.getScene().getWindow();
+			stage.close();
+		} else if (validSuccess && validName && noSalutation) {
+			String sal = "";
+			Person pers = new Person(sal.trim(), this.fullName.getText().trim(), this.famLast.isSelected());
 			this.account = new Account(pers, this.accountNo.getText().trim());
 			this.success = true;
 			Stage stage = (Stage) this.submit.getScene().getWindow();
@@ -207,6 +224,14 @@ public class AccountController implements Initializable {
 			invalidInputAlert.setContentText(invalidMessage);
 			invalidInputAlert.showAndWait();
 		}
+	}
+
+	/**
+	 * @param trim
+	 */
+	private void print(String trim) {
+		// TODO Auto-generated method stub
+		
 	}
 
 	/**
@@ -230,6 +255,17 @@ public class AccountController implements Initializable {
 			return false;
 		}
 	}
+	
+	public boolean handleEmptySalutation() {
+		emptySalutationAlert.setContentText("Are you sure you don't want to add a salutation?");
+		Optional<ButtonType> result = emptySalutationAlert.showAndWait();
+		if (result.get() == ButtonType.OK) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+		
 
 	@Override
 	public void initialize(URL location, ResourceBundle resources) {

--- a/src/edu/wright/cs/raiderplanner/controller/AccountController.java
+++ b/src/edu/wright/cs/raiderplanner/controller/AccountController.java
@@ -88,7 +88,9 @@ public class AccountController implements Initializable {
 	 * @return true if the user entered a valid salutation.
 	 */
 	public boolean validateSalutation() {
-		if (!Person.validSalutation(this.salutation.getSelectionModel().getSelectedItem().trim())) {
+		if (this.salutation.getValue() == null ) {
+			return false;
+		} else if (!Person.validSalutation(this.salutation.getSelectionModel().getSelectedItem().trim())) {
 			return false;
 		} else {
 			this.salutation.setStyle("");
@@ -97,9 +99,11 @@ public class AccountController implements Initializable {
 	}
 
 	/**
-	 * Determines if the user has entered a valid name by calling the validateName()
-	 * from the Person Class in Model, which checks that the entered Name only
-	 * contains a combination of spaces and upper/lower case letters and returns
+	 * Determines if the user has made a salutation selection by checking if
+	 * the salutation value is null. then determines if the user has 
+	 * entered a valid name by calling the validateName() from the Person 
+	 * Class in Model, which checks that the entered Name only contains a 
+	 * combination of spaces and upper/lower case letters and returns
 	 * a boolean value. Then sets the style so it is cohesive.
 	 * @return True if the user entered a valid name.
 	 */


### PR DESCRIPTION
This pull request has fixed and updated the salutation function of the initial login form. The system now handles a salutation not chosen without any errors when the form is submitted. The initial error was due to the fact that when a salutation is not chosen, the value is set to null. When the function trying to validate the salutation tried to pull its value, it was getting null which caused it to break. The function now first checks if the value is null before pulling the value. 

This pull request has also added functionality to the salutation function of the initial login form. Users will now have the option to not choose a salutation. If no salutation is chosen, an alert box asking the user if they really do not want to choose a salutation pops up. If the user hits the ok button, the form submits, otherwise the alert disappears and the form stays up.